### PR TITLE
Get rid of persistent Fly volume

### DIFF
--- a/dev-scripts/upload-prod-db
+++ b/dev-scripts/upload-prod-db
@@ -17,10 +17,10 @@ set +x
 set -x
 
 if [[ -z "${DB_PATH}" ]]; then
-      echo "usage: upload-prod-db [db_path]" && exit 1
+      echo "usage: upload-prod-db db_path" && exit 1
 fi
 
-read -p -r "Really overwrite prod database? (y/N): " choice
+read -r -p "Really overwrite prod database? (y/N): " choice
 
 echo "Choice is ${choice}"
 

--- a/fly.toml
+++ b/fly.toml
@@ -10,10 +10,6 @@ processes = []
   LITESTREAM_BUCKET="screenjournal-litestream"
   LITESTREAM_ENDPOINT="s3.us-west-002.backblazeb2.com"
 
-[mounts]
-  source="screenjournal_data"
-  destination="/data"
-
 [experimental]
   allowed_public_ports = []
   auto_rollback = true


### PR DESCRIPTION
It makes caching logic more confusing, and the data we need to store is small enough to fit in a temp VM.