### PR TITLE
Change EndSession to take an *http.Request

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -40,7 +40,7 @@ func (s Server) authPost() http.HandlerFunc {
 
 func (s Server) authDelete() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := s.sessionManager.EndSession(r.Context(), w); err != nil {
+		if err := s.sessionManager.EndSession(r, w); err != nil {
 			log.Printf("error terminating user session: %v", err)
 		}
 	}
@@ -53,7 +53,7 @@ func (s Server) populateAuthenticationContext(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		} else if err != nil {
-			if err := s.sessionManager.EndSession(r.Context(), w); err != nil {
+			if err := s.sessionManager.EndSession(r, w); err != nil {
 				log.Printf("error terminating user session: %v", err)
 			}
 			http.Error(w, fmt.Sprintf("Invalid session token: %v", err), http.StatusBadRequest)
@@ -69,7 +69,7 @@ func (s Server) populateAuthenticationContext(next http.Handler) http.Handler {
 func (s Server) requireAuthentication(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := userFromContext(r.Context()); !ok {
-			if err := s.sessionManager.EndSession(r.Context(), w); err != nil {
+			if err := s.sessionManager.EndSession(r, w); err != nil {
 				log.Printf("error terminating user session: %v", err)
 			}
 			http.Error(w, "Authentication required", http.StatusUnauthorized)

--- a/handlers/reviews_test.go
+++ b/handlers/reviews_test.go
@@ -1,7 +1,6 @@
 package handlers_test
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -42,7 +41,7 @@ func (sm mockSessionManager) SessionFromRequest(*http.Request) (sessions.Session
 	}, nil
 }
 
-func (sm mockSessionManager) EndSession(context.Context, http.ResponseWriter) error {
+func (sm mockSessionManager) EndSession(*http.Request, http.ResponseWriter) error {
 	return nil
 }
 

--- a/handlers/sessions/sessions.go
+++ b/handlers/sessions/sessions.go
@@ -1,7 +1,6 @@
 package sessions
 
 import (
-	"context"
 	"errors"
 	"net/http"
 
@@ -12,7 +11,7 @@ type (
 	Manager interface {
 		CreateSession(http.ResponseWriter, *http.Request, screenjournal.Username) error
 		SessionFromRequest(*http.Request) (Session, error)
-		EndSession(context.Context, http.ResponseWriter) error
+		EndSession(*http.Request, http.ResponseWriter) error
 	}
 
 	Session struct {

--- a/handlers/sessions/simple/simple.go
+++ b/handlers/sessions/simple/simple.go
@@ -1,7 +1,6 @@
 package simple
 
 import (
-	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
@@ -74,7 +73,7 @@ func (m manager) SessionFromRequest(r *http.Request) (sessions.Session, error) {
 	}, nil
 }
 
-func (m manager) EndSession(ctx context.Context, w http.ResponseWriter) error {
+func (m manager) EndSession(_ *http.Request, w http.ResponseWriter) error {
 	// The simple manager can't really invalidate sessions because the credentials
 	// are hard-coded and the session token is static, so all we can do is ask the
 	// client to delete their cookie.


### PR DESCRIPTION
The gorilla/sessions package needs the whole request, so we're adjusting the semantics slightly.