### PR TITLE
Make authenticator responsible for managing user attributes

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Authenticator interface {
-	Authenticate(screenjournal.Username, screenjournal.Password) error
+	Authenticate(screenjournal.Username, screenjournal.Password) (screenjournal.User, error)
 }
 
 var ErrInvalidCredentials = errors.New("invalid credentials")

--- a/auth/simple/simple.go
+++ b/auth/simple/simple.go
@@ -9,25 +9,28 @@ import (
 
 type (
 	authenticator struct {
-		username screenjournal.Username
-		password screenjournal.Password
+		adminUsername screenjournal.Username
+		adminPassword screenjournal.Password
 	}
 )
 
-func New(username screenjournal.Username, password screenjournal.Password) (authenticator, error) {
+func New(adminUsername screenjournal.Username, adminPassword screenjournal.Password) (authenticator, error) {
 	return authenticator{
-		username: username,
-		password: password,
+		adminUsername: adminUsername,
+		adminPassword: adminPassword,
 	}, nil
 }
 
-func (a authenticator) Authenticate(username screenjournal.Username, password screenjournal.Password) error {
+func (a authenticator) Authenticate(username screenjournal.Username, password screenjournal.Password) (screenjournal.User, error) {
 	// This is an insecure, placeholder implementation for authentication until we
 	// switch to bcrypt.
-	valid := []byte(a.username.String() + a.password.String())
+	valid := []byte(a.adminUsername.String() + a.adminPassword.String())
 	attempt := []byte(username.String() + password.String())
 	if subtle.ConstantTimeCompare(valid, attempt) != 1 {
-		return auth.ErrInvalidCredentials
+		return screenjournal.User{}, auth.ErrInvalidCredentials
 	}
-	return nil
+	return screenjournal.User{
+		Username: username,
+		IsAdmin:  username.Equal(a.adminUsername),
+	}, nil
 }

--- a/cmd/screenjournal/main.go
+++ b/cmd/screenjournal/main.go
@@ -36,7 +36,7 @@ func main() {
 	ensureDirExists(filepath.Dir(*dbPath))
 	store := sqlite.New(*dbPath, isLitestreamEnabled())
 
-	sessionManager, err := jeff_sessions.New(adminUsername, *dbPath)
+	sessionManager, err := jeff_sessions.New(*dbPath)
 	if err != nil {
 		log.Fatalf("failed to create session manager: %v", err)
 	}

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -26,12 +26,13 @@ func (s Server) authPost() http.HandlerFunc {
 			return
 		}
 
-		if err := s.authenticator.Authenticate(username, password); err != nil {
+		user, err := s.authenticator.Authenticate(username, password)
+		if err != nil {
 			http.Error(w, fmt.Sprintf("Invalid credentials: %v", err), http.StatusUnauthorized)
 			return
 		}
 
-		if err := s.sessionManager.CreateSession(w, r, username); err != nil {
+		if err := s.sessionManager.CreateSession(w, r, user); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to create session: %v", err), http.StatusInternalServerError)
 			return
 		}

--- a/handlers/reviews_test.go
+++ b/handlers/reviews_test.go
@@ -23,13 +23,13 @@ import (
 
 type mockAuthenticator struct{}
 
-func (a mockAuthenticator) Authenticate(screenjournal.Username, screenjournal.Password) error {
-	return nil
+func (a mockAuthenticator) Authenticate(screenjournal.Username, screenjournal.Password) (screenjournal.User, error) {
+	return screenjournal.User{}, nil
 }
 
 type mockSessionManager struct{}
 
-func (sm mockSessionManager) CreateSession(http.ResponseWriter, *http.Request, screenjournal.Username) error {
+func (sm mockSessionManager) CreateSession(http.ResponseWriter, *http.Request, screenjournal.User) error {
 	return nil
 }
 

--- a/handlers/sessions/sessions.go
+++ b/handlers/sessions/sessions.go
@@ -9,7 +9,7 @@ import (
 
 type (
 	Manager interface {
-		CreateSession(http.ResponseWriter, *http.Request, screenjournal.Username) error
+		CreateSession(http.ResponseWriter, *http.Request, screenjournal.User) error
 		SessionFromRequest(*http.Request) (Session, error)
 		EndSession(*http.Request, http.ResponseWriter) error
 		WrapRequest(http.Handler) http.Handler


### PR DESCRIPTION
This change eliminates the need for the session manager to manage any details about the session. Instead, it serializes the user metadata generated by the authenticator and inserts that metadata into the session.