### PR TITLE
Treat release date as UTC

### DIFF
--- a/handlers/templates/custom-elements/title-search.html
+++ b/handlers/templates/custom-elements/title-search.html
@@ -149,7 +149,7 @@
 
               const spanEl = document.createElement("span");
               spanEl.classList.add("title");
-              spanEl.innerText = `${m.title} (${d.getFullYear()})`;
+              spanEl.innerText = `${m.title} (${d.getUTCFullYear()})`;
 
               const anchorEl = document.createElement("a");
               anchorEl.href = "#";


### PR DESCRIPTION
Otherwise, if it falls on Jan. 1st, JavaScript auto-converts it to local time, which is the previous year