### PR TITLE
Reduce playwright timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { devices } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
   testDir: "./e2e",
-  timeout: 30 * 1000,
+  timeout: 5 * 1000,
   expect: {
     timeout: 5 * 1000,
   },


### PR DESCRIPTION
30s is too long. 5s should be sufficient.