### PR TITLE
Reduce the number of generally reserved words

### DIFF
--- a/handlers/parse/reserved.go
+++ b/handlers/parse/reserved.go
@@ -1,9 +1,13 @@
 package parse
 
-var reservedWords = []string{"undefined", "null", "root", "admin", "add", "edit", "delete", "copy"}
+var reservedWords = []string{"undefined", "null"}
 
 func isReservedWord(s string) bool {
-	for _, w := range reservedWords {
+	return isWordInSlice(s, reservedWords)
+}
+
+func isWordInSlice(s string, ss []string) bool {
+	for _, w := range ss {
 		if s == w {
 			return true
 		}

--- a/handlers/parse/username.go
+++ b/handlers/parse/username.go
@@ -11,10 +11,12 @@ var (
 	ErrInvalidUsername = errors.New("invalid username")
 
 	usernamePattern = regexp.MustCompile(`^[a-zA-Z\.0-9]{2,80}$`)
+
+	reservedUsernames = append(reservedWords, []string{"root", "admin", "add", "edit", "delete", "copy"}...)
 )
 
 func Username(username string) (screenjournal.Username, error) {
-	if isReservedWord(username) {
+	if isWordInSlice(username, reservedUsernames) {
 		return screenjournal.Username(""), ErrInvalidUsername
 	}
 


### PR DESCRIPTION
Only some of the reserved words need to be reserved globally. The rest should be reserved only in the context of usernames.