### PR TITLE
Get rid of data-testid in navbar

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -16,8 +16,8 @@ test("signs up and logs out and signs in again", async ({ page }) => {
 
   await expect(page).toHaveURL("/reviews");
 
-  await page.locator("#account-dropdown").click();
-  await page.locator("#navbar-log-out").click();
+  await page.getByRole("menuitem", { name: "Account" }).click();
+  await page.getByRole("menuitem", { name: "Log out" }).click();
 
   // Sign in again
   await expect(page).toHaveURL("/");
@@ -30,8 +30,8 @@ test("signs up and logs out and signs in again", async ({ page }) => {
 
   await expect(page).toHaveURL("/reviews");
 
-  await page.locator("#account-dropdown").click();
-  await page.locator("#navbar-log-out").click();
+  await page.getByRole("menuitem", { name: "Account" }).click();
+  await page.getByRole("menuitem", { name: "Log out" }).click();
 
   await expect(page).toHaveURL("/");
   await expect(page.getByRole("menuitem", { name: "Sign in" })).toBeVisible();
@@ -105,8 +105,8 @@ test("signs up fails after there's already an admin user", async ({ page }) => {
 
   await expect(page).toHaveURL("/reviews");
 
-  await page.locator("#account-dropdown").click();
-  await page.locator("#navbar-log-out").click();
+  await page.getByRole("menuitem", { name: "Account" }).click();
+  await page.getByRole("menuitem", { name: "Log out" }).click();
 
   // Attempt to sign up again
   await expect(page).toHaveURL("/");

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -5,7 +5,7 @@ import { loginAsUserA } from "./helpers/login.js";
 test("signs up and logs out and signs in again", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByTestId("sign-up-btn").click();
+  await page.getByRole("menuitem", { name: "Sign up" }).click();
 
   await expect(page).toHaveURL("/sign-up");
   await page.locator("id=username").fill("dummyadmin");
@@ -40,7 +40,7 @@ test("signs up and logs out and signs in again", async ({ page }) => {
 test("sign up fails if passwords are different", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByTestId("sign-up-btn").click();
+  await page.getByRole("menuitem", { name: "Sign up" }).click();
 
   await expect(page).toHaveURL("/sign-up");
   await page.locator("id=username").fill("dummyadmin");
@@ -58,7 +58,7 @@ test("sign up fails if passwords are different", async ({ page }) => {
 test("sign up fails if username is invalid", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByTestId("sign-up-btn").click();
+  await page.getByRole("menuitem", { name: "Sign up" }).click();
 
   await expect(page).toHaveURL("/sign-up");
   await page.locator("id=username").fill("root");
@@ -75,7 +75,7 @@ test("sign up fails if username is invalid", async ({ page }) => {
 test("sign up fails if password is too short", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByTestId("sign-up-btn").click();
+  await page.getByRole("menuitem", { name: "Sign up" }).click();
 
   await expect(page).toHaveURL("/sign-up");
   await page.locator("id=username").fill("dummyadmin");
@@ -94,7 +94,7 @@ test("sign up fails if password is too short", async ({ page }) => {
 test("signs up fails after there's already an admin user", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByTestId("sign-up-btn").click();
+  await page.getByRole("menuitem", { name: "Sign up" }).click();
 
   await expect(page).toHaveURL("/sign-up");
   await page.locator("id=username").fill("dummyadmin");
@@ -111,7 +111,7 @@ test("signs up fails after there's already an admin user", async ({ page }) => {
   // Attempt to sign up again
   await expect(page).toHaveURL("/");
 
-  await page.getByTestId("sign-up-btn").click();
+  await page.getByRole("menuitem", { name: "Sign up" }).click();
 
   await expect(page).toHaveURL("/sign-up");
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -21,7 +21,7 @@ test("signs up and logs out and signs in again", async ({ page }) => {
 
   // Sign in again
   await expect(page).toHaveURL("/");
-  await page.getByTestId("sign-in-btn").click();
+  await page.getByRole("menuitem", { name: "Sign in" }).click();
 
   await expect(page).toHaveURL("/login");
   await page.locator("id=username").fill("dummyadmin");
@@ -34,7 +34,7 @@ test("signs up and logs out and signs in again", async ({ page }) => {
   await page.locator("#navbar-log-out").click();
 
   await expect(page).toHaveURL("/");
-  await expect(page.getByTestId("sign-in-btn")).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Sign in" })).toBeVisible();
 });
 
 test("sign up fails if passwords are different", async ({ page }) => {

--- a/e2e/helpers/login.js
+++ b/e2e/helpers/login.js
@@ -3,7 +3,7 @@ import { expect } from "@playwright/test";
 async function loginAsUser(page, username, password) {
   await page.goto("/");
 
-  await page.getByTestId("sign-in-btn").click();
+  await page.getByRole("menuitem", { name: "Sign in" }).click();
 
   await expect(page).toHaveURL("/login");
   await page.locator("id=username").fill(username);

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -11,8 +11,8 @@ test("signing up with an valid invite code succeeds", async ({
   page,
   browser,
 }) => {
-  await page.locator("id=admin-dropdown").click();
-  await page.getByTestId("invites-btn").click();
+  await page.getByRole("menuitem", { name: "Admin" }).click();
+  await page.getByRole("menuitem", { name: "Invites" }).click();
 
   await expect(page).toHaveURL("/admin/invites");
   await page.getByTestId("create-invite").click();
@@ -55,8 +55,8 @@ test("signing up with an invalid invite code fails", async ({
   page,
   browser,
 }) => {
-  await page.locator("id=admin-dropdown").click();
-  await page.getByTestId("invites-btn").click();
+  await page.getByRole("menuitem", { name: "Admin" }).click();
+  await page.getByRole("menuitem", { name: "Invites" }).click();
 
   await expect(page).toHaveURL("/admin/invites");
   await page.getByTestId("create-invite").click();

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -10,7 +10,7 @@ test.beforeEach(async ({ page }) => {
 test("notifications page reflects the backend store for new reviews", async ({
   page,
 }) => {
-  await page.locator("#account-dropdown").click();
+  await page.getByRole("menuitem", { name: "Account" }).click();
   await page.getByRole("menuitem", { name: "Notifications" }).click();
 
   await expect(page).toHaveURL("/account/notifications");
@@ -46,7 +46,7 @@ test("notifications page reflects the backend store for new reviews", async ({
 test("notifications page reflects the backend store for new comments", async ({
   page,
 }) => {
-  await page.locator("#account-dropdown").click();
+  await page.getByRole("menuitem", { name: "Account" }).click();
   await page.getByRole("menuitem", { name: "Notifications" }).click();
 
   await expect(page).toHaveURL("/account/notifications");

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -11,7 +11,7 @@ test("notifications page reflects the backend store for new reviews", async ({
   page,
 }) => {
   await page.locator("#account-dropdown").click();
-  await page.getByTestId("notification-prefs-btn").click();
+  await page.getByRole("menuitem", { name: "Notifications" }).click();
 
   await expect(page).toHaveURL("/account/notifications");
 
@@ -47,7 +47,7 @@ test("notifications page reflects the backend store for new comments", async ({
   page,
 }) => {
   await page.locator("#account-dropdown").click();
-  await page.getByTestId("notification-prefs-btn").click();
+  await page.getByRole("menuitem", { name: "Notifications" }).click();
 
   await expect(page).toHaveURL("/account/notifications");
 

--- a/handlers/templates/partials/navbar.html
+++ b/handlers/templates/partials/navbar.html
@@ -71,8 +71,7 @@
               <a
                 class="nav-link dropdown-toggle"
                 href="#"
-                id="admin-dropdown"
-                role="button"
+                role="menuitem"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
               >
@@ -80,10 +79,7 @@
               </a>
               <ul class="dropdown-menu" aria-labelledby="account-dropdown">
                 <li>
-                  <a
-                    href="/admin/invites"
-                    class="dropdown-item"
-                    data-testid="invites-btn"
+                  <a href="/admin/invites" class="dropdown-item" role="menuitem"
                     >Invites</a
                   >
                 </li>
@@ -96,6 +92,7 @@
           <a
             href="/sign-up"
             class="btn btn-primary btn-sm px-4 gap-3"
+            role="menuitem"
             data-testid="sign-up-btn"
           >
             Sign up

--- a/handlers/templates/partials/navbar.html
+++ b/handlers/templates/partials/navbar.html
@@ -21,10 +21,10 @@
     <div class="collapse navbar-collapse" id="navbar-content">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link" href="{{ $homeRoute }}">Home</a>
+          <a class="nav-link" href="{{ $homeRoute }}" role="menuitem">Home</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about">About</a>
+          <a class="nav-link" href="/about" role="menuitem">About</a>
         </li>
       </ul>
       {{ if .IsAuthenticated }}
@@ -34,7 +34,7 @@
               class="nav-link dropdown-toggle"
               href="#"
               id="account-dropdown"
-              role="button"
+              role="menuitem"
               data-bs-toggle="dropdown"
               aria-expanded="false"
             >
@@ -45,6 +45,7 @@
                 <a
                   href="/reviews/by/{{ .LoggedInUsername }}"
                   class="dropdown-item"
+                  role="menuitem"
                   >My ratings</a
                 >
               </li>
@@ -52,12 +53,17 @@
                 <a
                   href="/account/notifications"
                   class="dropdown-item"
+                  role="menuitem"
                   data-testid="notification-prefs-btn"
                   >Notifications</a
                 >
               </li>
               <li>
-                <a id="navbar-log-out" href="/logout" class="dropdown-item"
+                <a
+                  id="navbar-log-out"
+                  href="/logout"
+                  class="dropdown-item"
+                  role="menuitem"
                   >Log out</a
                 >
               </li>
@@ -93,14 +99,13 @@
             href="/sign-up"
             class="btn btn-primary btn-sm px-4 gap-3"
             role="menuitem"
-            data-testid="sign-up-btn"
           >
             Sign up
           </a>
           <a
             href="/login"
             class="btn btn-outline-secondary btn-sm px-4 gap-3"
-            data-testid="sign-in-btn"
+            role="menuitem"
           >
             Sign in
           </a>

--- a/handlers/templates/partials/navbar.html
+++ b/handlers/templates/partials/navbar.html
@@ -54,7 +54,6 @@
                   href="/account/notifications"
                   class="dropdown-item"
                   role="menuitem"
-                  data-testid="notification-prefs-btn"
                   >Notifications</a
                 >
               </li>

--- a/handlers/templates/partials/navbar.html
+++ b/handlers/templates/partials/navbar.html
@@ -74,6 +74,7 @@
           <ul class="navbar-nav">
             <li class="nav-item dropdown">
               <a
+                id="admin-dropdown"
                 class="nav-link dropdown-toggle"
                 href="#"
                 role="menuitem"
@@ -82,7 +83,7 @@
               >
                 Admin
               </a>
-              <ul class="dropdown-menu" aria-labelledby="account-dropdown">
+              <ul class="dropdown-menu" aria-labelledby="admin-dropdown">
                 <li>
                   <a href="/admin/invites" class="dropdown-item" role="menuitem"
                     >Invites</a


### PR DESCRIPTION
We can locate elements by role in Playwright instead.