### PR TITLE
Fix COPY commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ COPY ./metadata /app/metadata
 COPY ./random /app/random
 COPY ./screenjournal /app/screenjournal
 COPY ./store /app/store
-COPY ./*.go /app/
 COPY ./go.* /app/
 
 WORKDIR /app


### PR DESCRIPTION
There are no more .go files in the root to copy.