### PR TITLE
Make mockMetadataFinder behave deterministically

### DIFF
--- a/handlers/reviews_test.go
+++ b/handlers/reviews_test.go
@@ -110,7 +110,7 @@ func (sm mockSessionManager) WrapRequest(next http.Handler) http.Handler {
 }
 
 type mockMetadataFinder struct {
-	db map[screenjournal.TmdbID]metadata.MovieInfo
+	db []metadata.MovieInfo
 }
 
 func (mf mockMetadataFinder) Search(query string) ([]metadata.MovieInfo, error) {
@@ -129,19 +129,17 @@ func (mf mockMetadataFinder) Search(query string) ([]metadata.MovieInfo, error) 
 }
 
 func (mf mockMetadataFinder) GetMovieInfo(id screenjournal.TmdbID) (metadata.MovieInfo, error) {
-	var m metadata.MovieInfo
-	var ok bool
-	if m, ok = mf.db[id]; !ok {
-		return metadata.MovieInfo{}, fmt.Errorf("could not find movie with id %d in mock DB", id.Int32())
+	for _, m := range mf.db {
+		if id.Equal(m.TmdbID) {
+			return m, nil
+		}
 	}
-	return m, nil
+	return metadata.MovieInfo{}, fmt.Errorf("could not find movie with id %d in mock DB", id.Int32())
 }
 
 func NewMockMetadataFinder(movies []metadata.MovieInfo) mockMetadataFinder {
-	db := map[screenjournal.TmdbID]metadata.MovieInfo{}
-	for _, m := range movies {
-		db[m.TmdbID] = m
-	}
+	db := make([]metadata.MovieInfo, len(movies))
+	copy(db, movies)
 	return mockMetadataFinder{db}
 }
 

--- a/screenjournal/metadata.go
+++ b/screenjournal/metadata.go
@@ -24,6 +24,10 @@ func (mid MovieID) String() string {
 	return strconv.FormatInt(mid.Int64(), 10)
 }
 
+func (m TmdbID) Equal(o TmdbID) bool {
+	return m.Int32() == o.Int32()
+}
+
 func (m TmdbID) Int32() int32 {
 	return int32(m)
 }


### PR DESCRIPTION
Maps don't always iterate in the same order, so we're simplifying to a slice.