### PR TITLE
Drop custom-elements block from base template

### DIFF
--- a/handlers/templates/layouts/base.html
+++ b/handlers/templates/layouts/base.html
@@ -36,8 +36,6 @@
   </head>
 
   <body>
-    {{ block "custom-elements" . }}{{ end }}
-
     {{ template "navbar.html" . }}
 
 


### PR DESCRIPTION
We no longer use it