### PR TITLE
Use -nixpkgs suffix in Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,7 @@
         "type": "github"
       }
     },
-    "flyctl_dep": {
+    "flyctl-nixpkgs": {
       "locked": {
         "lastModified": 1701998057,
         "narHash": "sha256-gAJGhcTO9cso7XDfAScXUlPcva427AUT2q02qrmXPdo=",
@@ -34,7 +34,7 @@
         "type": "github"
       }
     },
-    "go_dep": {
+    "go-nixpkgs": {
       "locked": {
         "lastModified": 1723635686,
         "narHash": "sha256-iNYh7Kb0D+MQ8IHM4+8bT1bUS5RNW6gVSDe2yTO1aAk=",
@@ -50,7 +50,7 @@
         "type": "github"
       }
     },
-    "litestream_dep": {
+    "litestream-nixpkgs": {
       "locked": {
         "lastModified": 1709905912,
         "narHash": "sha256-TofHtnlrOBCxtSZ9nnlsTybDnQXUmQrlIleXF1RQAwQ=",
@@ -66,7 +66,7 @@
         "type": "github"
       }
     },
-    "nodejs_dep": {
+    "nodejs-nixpkgs": {
       "locked": {
         "lastModified": 1694343207,
         "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
@@ -82,7 +82,7 @@
         "type": "github"
       }
     },
-    "playwright_dep": {
+    "playwright-nixpkgs": {
       "locked": {
         "lastModified": 1701336116,
         "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
@@ -101,16 +101,16 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "flyctl_dep": "flyctl_dep",
-        "go_dep": "go_dep",
-        "litestream_dep": "litestream_dep",
-        "nodejs_dep": "nodejs_dep",
-        "playwright_dep": "playwright_dep",
-        "shellcheck_dep": "shellcheck_dep",
-        "sqlfluff_dep": "sqlfluff_dep"
+        "flyctl-nixpkgs": "flyctl-nixpkgs",
+        "go-nixpkgs": "go-nixpkgs",
+        "litestream-nixpkgs": "litestream-nixpkgs",
+        "nodejs-nixpkgs": "nodejs-nixpkgs",
+        "playwright-nixpkgs": "playwright-nixpkgs",
+        "shellcheck-nixpkgs": "shellcheck-nixpkgs",
+        "sqlfluff-nixpkgs": "sqlfluff-nixpkgs"
       }
     },
-    "shellcheck_dep": {
+    "shellcheck-nixpkgs": {
       "locked": {
         "lastModified": 1695132891,
         "narHash": "sha256-cJR9AFHmt816cW/C9necLJyOg/gsnkvEeFAfxgeM1hc=",
@@ -126,7 +126,7 @@
         "type": "github"
       }
     },
-    "sqlfluff_dep": {
+    "sqlfluff-nixpkgs": {
       "locked": {
         "lastModified": 1660687964,
         "narHash": "sha256-8dJ8u/SUlJoHJVPFnFqoo7ugLH4RxyuyQTeuE6/EynE=",

--- a/flake.nix
+++ b/flake.nix
@@ -5,61 +5,61 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     # 1.23.0 release
-    go_dep.url = "github:NixOS/nixpkgs/0cb2fd7c59fed0cd82ef858cbcbdb552b9a33465";
+    go-nixpkgs.url = "github:NixOS/nixpkgs/0cb2fd7c59fed0cd82ef858cbcbdb552b9a33465";
 
     # 20.6.1 release
-    nodejs_dep.url = "github:NixOS/nixpkgs/78058d810644f5ed276804ce7ea9e82d92bee293";
+    nodejs-nixpkgs.url = "github:NixOS/nixpkgs/78058d810644f5ed276804ce7ea9e82d92bee293";
 
     # 0.9.0 release
-    shellcheck_dep.url = "github:NixOS/nixpkgs/8b5ab8341e33322e5b66fb46ce23d724050f6606";
+    shellcheck-nixpkgs.url = "github:NixOS/nixpkgs/8b5ab8341e33322e5b66fb46ce23d724050f6606";
 
     # 1.2.1 release
-    sqlfluff_dep.url = "github:NixOS/nixpkgs/7cf5ccf1cdb2ba5f08f0ac29fc3d04b0b59a07e4";
+    sqlfluff-nixpkgs.url = "github:NixOS/nixpkgs/7cf5ccf1cdb2ba5f08f0ac29fc3d04b0b59a07e4";
 
     # 1.40.0
-    playwright_dep.url = "github:NixOS/nixpkgs/f5c27c6136db4d76c30e533c20517df6864c46ee";
+    playwright-nixpkgs.url = "github:NixOS/nixpkgs/f5c27c6136db4d76c30e533c20517df6864c46ee";
 
     # 0.1.131 release
-    flyctl_dep.url = "github:NixOS/nixpkgs/09dc04054ba2ff1f861357d0e7e76d021b273cd7";
+    flyctl-nixpkgs.url = "github:NixOS/nixpkgs/09dc04054ba2ff1f861357d0e7e76d021b273cd7";
 
     # 0.3.13 release
-    litestream_dep.url = "github:NixOS/nixpkgs/a343533bccc62400e8a9560423486a3b6c11a23b";
+    litestream-nixpkgs.url = "github:NixOS/nixpkgs/a343533bccc62400e8a9560423486a3b6c11a23b";
   };
 
-  outputs = { self, flake-utils, go_dep, nodejs_dep, shellcheck_dep, sqlfluff_dep, playwright_dep, flyctl_dep, litestream_dep }@inputs :
+  outputs = { self, flake-utils, go-nixpkgs, nodejs-nixpkgs, shellcheck-nixpkgs, sqlfluff-nixpkgs, playwright-nixpkgs, flyctl-nixpkgs, litestream-nixpkgs }@inputs :
     flake-utils.lib.eachDefaultSystem (system:
     let
-      go_dep = inputs.go_dep.legacyPackages.${system};
-      nodejs_dep = inputs.nodejs_dep.legacyPackages.${system};
-      shellcheck_dep = inputs.shellcheck_dep.legacyPackages.${system};
-      sqlfluff_dep = inputs.sqlfluff_dep.legacyPackages.${system};
-      playwright_dep = inputs.playwright_dep.legacyPackages.${system};
-      flyctl_dep = inputs.flyctl_dep.legacyPackages.${system};
-      litestream_dep = inputs.litestream_dep.legacyPackages.${system};
+      go-nixpkgs = inputs.go-nixpkgs.legacyPackages.${system};
+      nodejs-nixpkgs = inputs.nodejs-nixpkgs.legacyPackages.${system};
+      shellcheck-nixpkgs = inputs.shellcheck-nixpkgs.legacyPackages.${system};
+      sqlfluff-nixpkgs = inputs.sqlfluff-nixpkgs.legacyPackages.${system};
+      playwright-nixpkgs = inputs.playwright-nixpkgs.legacyPackages.${system};
+      flyctl-nixpkgs = inputs.flyctl-nixpkgs.legacyPackages.${system};
+      litestream-nixpkgs = inputs.litestream-nixpkgs.legacyPackages.${system};
     in
     {
-      devShells.default = go_dep.mkShell.override { stdenv = go_dep.pkgsStatic.stdenv; } {
+      devShells.default = go-nixpkgs.mkShell.override { stdenv = go-nixpkgs.pkgsStatic.stdenv; } {
         packages = [
-          go_dep.gotools
-          go_dep.gopls
-          go_dep.go-outline
-          go_dep.gopkgs
-          go_dep.gocode-gomod
-          go_dep.godef
-          go_dep.golint
-          go_dep.go_1_23
-          nodejs_dep.nodejs_20
-          shellcheck_dep.shellcheck
-          sqlfluff_dep.sqlfluff
-          playwright_dep.playwright-driver.browsers
-          flyctl_dep.flyctl
-          litestream_dep.litestream
+          go-nixpkgs.gotools
+          go-nixpkgs.gopls
+          go-nixpkgs.go-outline
+          go-nixpkgs.gopkgs
+          go-nixpkgs.gocode-gomod
+          go-nixpkgs.godef
+          go-nixpkgs.golint
+          go-nixpkgs.go_1_23
+          nodejs-nixpkgs.nodejs_20
+          shellcheck-nixpkgs.shellcheck
+          sqlfluff-nixpkgs.sqlfluff
+          playwright-nixpkgs.playwright-driver.browsers
+          flyctl-nixpkgs.flyctl
+          litestream-nixpkgs.litestream
         ];
 
         shellHook = ''
-          export GOROOT="${go_dep.go_1_23}/share/go"
+          export GOROOT="${go-nixpkgs.go_1_23}/share/go"
 
-          export PLAYWRIGHT_BROWSERS_PATH=${playwright_dep.playwright-driver.browsers}
+          export PLAYWRIGHT_BROWSERS_PATH=${playwright-nixpkgs.playwright-driver.browsers}
           export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
 
           echo "shellcheck" "$(shellcheck --version | grep '^version:')"


### PR DESCRIPTION
The -nixpkgs suffix makes it clearer that it's a nixpkgs version for a particular dependency.