### PR TITLE
Fix login flow on e2e tests

### DIFF
--- a/e2e/helpers/db.js
+++ b/e2e/helpers/db.js
@@ -4,6 +4,7 @@ export async function populateDummyData(page) {
   await page.goto("/"); // hack to populate the DB cookie
   const response = await page.goto("/api/debug/db/populate-dummy-data");
   await expect(response?.status()).toBe(200);
+  await page.goto("/");
 }
 
 export function readDbTokenCookie(cookies) {

--- a/e2e/helpers/login.js
+++ b/e2e/helpers/login.js
@@ -1,8 +1,6 @@
 import { expect } from "@playwright/test";
 
 export async function loginAsUser(page, username, password) {
-  await page.goto("/");
-
   await page.getByRole("menuitem", { name: "Log in" }).click();
 
   await page.getByRole("textbox", { name: /username/i }).fill(username);

--- a/e2e/reviews.spec.ts
+++ b/e2e/reviews.spec.ts
@@ -493,6 +493,7 @@ test("editing another user's review fails", async ({ page, browser }) => {
     readDbTokenCookie(await page.context().cookies()),
   ]);
   const guestPage = await guestContext.newPage();
+  await guestPage.goto("/");
   await loginAsUserB(guestPage);
 
   const response = await guestPage.goto("/reviews/3/edit");


### PR DESCRIPTION
The extra page nav isn't necessary and causes flaky tests.