### PR TITLE
Simplify hx-disabled-elt attribute

### DIFF
--- a/handlers/templates/fragments/comments-edit.html
+++ b/handlers/templates/fragments/comments-edit.html
@@ -8,9 +8,7 @@
     hx-post="/api/comments"
   {{ end }}
   hx-swap="outerHTML"
-  data-comment-id="{{ .CommentID }}"
-  {{/* Workaround for https://github.com/bigskysoftware/htmx/issues/2660 */}}
-  hx-disabled-elt="[data-comment-id='{{ .CommentID }}'] textarea, [data-comment-id='{{ .CommentID }}'] .btn"
+  hx-disabled-elt="textarea, .btn"
 >
   {{ if not $isEditing }}
     <input type="hidden" name="review-id" value="{{ .ReviewID }}" />


### PR DESCRIPTION
I realized I don't need to use fancy find selectors because I can just do the normal selectors separated by commas.