### PR TITLE
Make form handling consistent on password reset page

### DIFF
--- a/e2e/passwordReset.spec.ts
+++ b/e2e/passwordReset.spec.ts
@@ -58,14 +58,34 @@ test("user can reset password via forgot-password flow", async ({
   await userPage.goto(resetLink);
   await expect(userPage).toHaveURL(resetLink);
 
+  await userPage.route(
+    /\/account\/password-reset\?username=userA&token=.*/,
+    async (route) => {
+      if (route.request().method() === "PUT") {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      await route.continue();
+    }
+  );
+
   // Reset password.
   await expect(userPage.getByLabel("Current Password")).not.toBeVisible();
   await userPage.getByLabel(/^New Password$/).fill("brandnewpass99");
   await userPage.getByLabel("Confirm New Password").fill("brandnewpass99");
+  const passwordResetResponse = userPage.waitForResponse((response) => {
+    return (
+      response.request().method() === "PUT" &&
+      response.url().includes("/account/password-reset?username=userA&token=")
+    );
+  });
   await userPage.getByRole("button", { name: /Reset password/i }).click();
+  await expect(userPage.getByLabel(/^New Password$/)).toBeDisabled();
+  await expect(userPage.getByLabel("Confirm New Password")).toBeDisabled();
+  await passwordResetResponse;
 
   // Verify successful reset.
   await expect(userPage.getByText("Password updated")).toBeVisible();
+  await expect(userPage.locator("#password-form")).toBeHidden();
 
   // User should be redirected to reviews after password reset.
   await expect(userPage).toHaveURL("/reviews");

--- a/handlers/templates/pages/account-change-password.html
+++ b/handlers/templates/pages/account-change-password.html
@@ -7,7 +7,7 @@
     class="mt-5"
     id="password-form"
     hx-put="{{ .FormTargetURL }}"
-    hx-disabled-elt="input, .btn"
+    hx-disabled-elt="input, button, select, textarea"
     hx-target="#result-success"
     hx-target-error="#result-error"
     hx-clear="#result-success, #result-error"
@@ -85,6 +85,26 @@
 
 {{ define "script-tags" }}
   <script type="module" nonce="{{ .CspNonce }}">
+    const passwordForm = document.getElementById("password-form");
+    const isPasswordReset = document.getElementById("reset-token") !== null;
+    let hasCompletedPasswordReset = false;
+
+    function isPasswordFormRequest(evt) {
+      const requestElt = evt.detail.elt;
+      return (
+        requestElt === passwordForm ||
+        requestElt.closest("#password-form") === passwordForm
+      );
+    }
+
+    function setPasswordFormDisabled(disabled) {
+      passwordForm
+        .querySelectorAll("input, button, select, textarea")
+        .forEach((el) => {
+          el.disabled = disabled;
+        });
+    }
+
     // Check that password and confirm-password match.
     document
       .getElementById("password-confirm")
@@ -99,21 +119,45 @@
         }
       });
 
+    document.body.addEventListener("htmx:beforeRequest", function (evt) {
+      if (!isPasswordFormRequest(evt)) {
+        return;
+      }
+      setPasswordFormDisabled(true);
+    });
+
     document.body.addEventListener("htmx:afterRequest", function (evt) {
+      if (!isPasswordFormRequest(evt)) {
+        return;
+      }
+
+      setPasswordFormDisabled(false);
+
       if (evt.detail.successful) {
         // Clear password inputs on success.
         document.querySelectorAll("input[type='password']").forEach((el) => {
           el.value = "";
         });
-
-        const isPasswordReset = document.getElementById("reset-token") !== null;
-        if (isPasswordReset) {
-          // If this was a password reset, redirect to root (user is now logged in)
-          setTimeout(function () {
-            window.location.href = "/";
-          }, 2000);
-        }
       }
+    });
+
+    document.body.addEventListener("htmx:afterSwap", function (evt) {
+      if (
+        !isPasswordReset ||
+        hasCompletedPasswordReset ||
+        evt.detail.target.id !== "result-success" ||
+        evt.detail.target.textContent.trim() === ""
+      ) {
+        return;
+      }
+
+      hasCompletedPasswordReset = true;
+      passwordForm.hidden = true;
+
+      // If this was a password reset, redirect to root (user is now logged in)
+      setTimeout(function () {
+        window.location.href = "/";
+      }, 2000);
     });
   </script>
 {{ end }}

--- a/handlers/templates/pages/account-change-password.html
+++ b/handlers/templates/pages/account-change-password.html
@@ -7,7 +7,7 @@
     class="mt-5"
     id="password-form"
     hx-put="{{ .FormTargetURL }}"
-    hx-disabled-elt="input, button, select, textarea"
+    hx-disabled-elt="input"
     hx-target="#result-success"
     hx-target-error="#result-error"
     hx-clear="#result-success, #result-error"
@@ -86,24 +86,6 @@
 {{ define "script-tags" }}
   <script type="module" nonce="{{ .CspNonce }}">
     const passwordForm = document.getElementById("password-form");
-    const isPasswordReset = document.getElementById("reset-token") !== null;
-    let hasCompletedPasswordReset = false;
-
-    function isPasswordFormRequest(evt) {
-      const requestElt = evt.detail.elt;
-      return (
-        requestElt === passwordForm ||
-        requestElt.closest("#password-form") === passwordForm
-      );
-    }
-
-    function setPasswordFormDisabled(disabled) {
-      passwordForm
-        .querySelectorAll("input, button, select, textarea")
-        .forEach((el) => {
-          el.disabled = disabled;
-        });
-    }
 
     // Check that password and confirm-password match.
     document
@@ -119,45 +101,26 @@
         }
       });
 
-    document.body.addEventListener("htmx:beforeRequest", function (evt) {
-      if (!isPasswordFormRequest(evt)) {
-        return;
-      }
-      setPasswordFormDisabled(true);
-    });
-
     document.body.addEventListener("htmx:afterRequest", function (evt) {
-      if (!isPasswordFormRequest(evt)) {
+      if (evt.detail.elt !== passwordForm) {
         return;
       }
-
-      setPasswordFormDisabled(false);
 
       if (evt.detail.successful) {
         // Clear password inputs on success.
         document.querySelectorAll("input[type='password']").forEach((el) => {
           el.value = "";
         });
+
+        if (document.getElementById("reset-token") !== null) {
+          passwordForm.hidden = true;
+
+          // If this was a password reset, redirect to root (user is now logged in)
+          setTimeout(function () {
+            window.location.href = "/";
+          }, 2000);
+        }
       }
-    });
-
-    document.body.addEventListener("htmx:afterSwap", function (evt) {
-      if (
-        !isPasswordReset ||
-        hasCompletedPasswordReset ||
-        evt.detail.target.id !== "result-success" ||
-        evt.detail.target.textContent.trim() === ""
-      ) {
-        return;
-      }
-
-      hasCompletedPasswordReset = true;
-      passwordForm.hidden = true;
-
-      // If this was a password reset, redirect to root (user is now logged in)
-      setTimeout(function () {
-        window.location.href = "/";
-      }, 2000);
     });
   </script>
 {{ end }}


### PR DESCRIPTION
Hide the form on success and disable inputs when request is in flight.