### PR TITLE
Fix GOROOT to match Go 1.26 in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,8 @@
           PROJECT_NAME="$(basename "$PWD")"
           export GOPATH="$HOME/.local/share/go-workspaces/$PROJECT_NAME"
 
-          # Override GOROOT set by Go tools (built with older Go) to match our Go version.
+          # Override GOROOT set by Go tools (built with older Go) to match our
+          # Go version.
           export GOROOT='${go}/share/go'
 
           export PLAYWRIGHT_BROWSERS_PATH=${playwright}

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,9 @@
           PROJECT_NAME="$(basename "$PWD")"
           export GOPATH="$HOME/.local/share/go-workspaces/$PROJECT_NAME"
 
+          # Override GOROOT set by Go tools (built with older Go) to match our Go version.
+          export GOROOT='${go}/share/go'
+
           export PLAYWRIGHT_BROWSERS_PATH=${playwright}
           export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
 


### PR DESCRIPTION
The Go tools (gotools, gopls, etc.) from nixpkgs are built with Go 1.23 and inject their build-time GOROOT into the shell environment. This explicitly sets GOROOT to point to Go 1.26 to match the actual Go binary.