### PR TITLE
Use memdb for ephemeral SQLite test databases

### DIFF
--- a/store/test_sqlite/db.go
+++ b/store/test_sqlite/db.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/ncruces/go-sqlite3/vfs/memdb"
+
 	"github.com/mtlynch/screenjournal/v2/random"
 	"github.com/mtlynch/screenjournal/v2/store/sqlite"
 )
@@ -20,7 +22,11 @@ func ephemeralDbURI() string {
 	name := random.String(
 		10,
 		[]rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
-	return fmt.Sprintf("file:%s?mode=memory&cache=shared", name)
+	memdb.Create("/"+name, nil)
+
+	// Use memdb instead of shared-cache in-memory DBs:
+	// https://github.com/ncruces/go-sqlite3/discussions/97#discussioncomment-9744524
+	return fmt.Sprintf("file:/%s?vfs=memdb", name)
 }
 
 // quietLogs suppresses log output during a function execution.


### PR DESCRIPTION
Replace the shared-cache in-memory test database URI in store/test_sqlite with a named memdb database.

Create a unique memdb database for each helper invocation and open it with a file URI that uses vfs=memdb. This keeps the helper API parameterless while following the upstream guidance cited in the code comment to avoid shared-cache in-memory databases for this test setup.