### PR TITLE
Rename SQLite store ctx field to db

### DIFF
--- a/store/sqlite/comments.go
+++ b/store/sqlite/comments.go
@@ -15,7 +15,7 @@ func (s Store) ReadComments(rid screenjournal.ReviewID) ([]screenjournal.ReviewC
 		return []screenjournal.ReviewComment{}, err
 	}
 
-	rows, err := s.ctx.Query(`
+	rows, err := s.db.Query(`
 	SELECT
 		id,
 		review_id,
@@ -58,7 +58,7 @@ func (s Store) ReadComments(rid screenjournal.ReviewID) ([]screenjournal.ReviewC
 }
 
 func (s Store) ReadComment(cid screenjournal.CommentID) (screenjournal.ReviewComment, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		review_id,
@@ -80,7 +80,7 @@ func (s Store) InsertComment(rc screenjournal.ReviewComment) (screenjournal.Comm
 
 	now := time.Now()
 
-	res, err := s.ctx.Exec(`
+	res, err := s.db.Exec(`
 	INSERT INTO
 		review_comments
 	(
@@ -114,7 +114,7 @@ func (s Store) InsertComment(rc screenjournal.ReviewComment) (screenjournal.Comm
 func (s Store) UpdateComment(rc screenjournal.ReviewComment) error {
 	log.Printf("updating comment %v from %v", rc.ID, rc.Owner)
 
-	_, err := s.ctx.Exec(`
+	_, err := s.db.Exec(`
 		UPDATE review_comments
 		SET
 			comment_text = :comment_text,
@@ -134,7 +134,7 @@ func (s Store) UpdateComment(rc screenjournal.ReviewComment) error {
 
 func (s Store) DeleteComment(cid screenjournal.CommentID) error {
 	log.Printf("deleting comment ID=%v", cid)
-	_, err := s.ctx.Exec(`DELETE FROM review_comments WHERE id = :id`, sql.Named("id", cid.String()))
+	_, err := s.db.Exec(`DELETE FROM review_comments WHERE id = :id`, sql.Named("id", cid.String()))
 	if err != nil {
 		return err
 	}

--- a/store/sqlite/invites.go
+++ b/store/sqlite/invites.go
@@ -13,7 +13,7 @@ func (s Store) InsertSignupInvitation(invite screenjournal.SignupInvitation) err
 
 	now := time.Now()
 
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 	INSERT INTO
 		invites
 	(
@@ -36,7 +36,7 @@ func (s Store) InsertSignupInvitation(invite screenjournal.SignupInvitation) err
 
 func (s Store) ReadSignupInvitation(code screenjournal.InviteCode) (screenjournal.SignupInvitation, error) {
 	var invitee string
-	if err := s.ctx.QueryRow(`
+	if err := s.db.QueryRow(`
 		SELECT
 			invitee
 		FROM
@@ -53,7 +53,7 @@ func (s Store) ReadSignupInvitation(code screenjournal.InviteCode) (screenjourna
 }
 
 func (s Store) ReadSignupInvitations() ([]screenjournal.SignupInvitation, error) {
-	rows, err := s.ctx.Query(`
+	rows, err := s.db.Query(`
 		SELECT
 			invitee,
 			code
@@ -92,7 +92,7 @@ func (s Store) ReadSignupInvitations() ([]screenjournal.SignupInvitation, error)
 
 func (s Store) DeleteSignupInvitation(code screenjournal.InviteCode) error {
 	log.Printf("deleting signup code: %s", code)
-	_, err := s.ctx.Exec(`DELETE FROM invites WHERE code = :code`, sql.Named("code", code.String()))
+	_, err := s.db.Exec(`DELETE FROM invites WHERE code = :code`, sql.Named("code", code.String()))
 	if err != nil {
 		return err
 	}

--- a/store/sqlite/litestream.go
+++ b/store/sqlite/litestream.go
@@ -3,7 +3,7 @@ package sqlite
 import "log"
 
 func (s Store) optimizeForLitestream() {
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 		-- Apply Litestream recommendations: https://litestream.io/tips/
 		PRAGMA busy_timeout = 5000;
 		PRAGMA synchronous = NORMAL;

--- a/store/sqlite/migrations.go
+++ b/store/sqlite/migrations.go
@@ -18,7 +18,7 @@ func (s Store) applyMigrations() {
 		log.Fatalf("failed to load migration files: %v", err)
 	}
 
-	if err := migrate.Run(context.Background(), s.ctx, migrationsRoot); err != nil {
+	if err := migrate.Run(context.Background(), s.db, migrationsRoot); err != nil {
 		log.Fatalf("failed to apply migrations: %v", err)
 	}
 }

--- a/store/sqlite/movies.go
+++ b/store/sqlite/movies.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s Store) ReadMovie(id screenjournal.MovieID) (screenjournal.Movie, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		tmdb_id,
@@ -27,7 +27,7 @@ func (s Store) ReadMovie(id screenjournal.MovieID) (screenjournal.Movie, error) 
 }
 
 func (s Store) ReadMovieByTmdbID(tmdbID screenjournal.TmdbID) (screenjournal.Movie, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		tmdb_id,
@@ -46,7 +46,7 @@ func (s Store) ReadMovieByTmdbID(tmdbID screenjournal.TmdbID) (screenjournal.Mov
 func (s Store) InsertMovie(m screenjournal.Movie) (screenjournal.MovieID, error) {
 	log.Printf("inserting new movie %s", m.Title)
 
-	res, err := s.ctx.Exec(`
+	res, err := s.db.Exec(`
 	INSERT INTO
 		movies
 	(
@@ -80,7 +80,7 @@ func (s Store) InsertMovie(m screenjournal.Movie) (screenjournal.MovieID, error)
 func (s Store) UpdateMovie(m screenjournal.Movie) error {
 	log.Printf("updating movie information for %s (id=%v)", m.Title, m.ID)
 
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 	UPDATE movies
 	SET
 		title = :title,

--- a/store/sqlite/notifications.go
+++ b/store/sqlite/notifications.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s Store) ReadReviewSubscribers() ([]screenjournal.EmailSubscriber, error) {
-	rows, err := s.ctx.Query(`
+	rows, err := s.db.Query(`
 	SELECT
 		users.username AS username,
 		users.email AS email
@@ -47,7 +47,7 @@ func (s Store) ReadCommentSubscribers(
 	reviewID screenjournal.ReviewID,
 	commentAuthor screenjournal.Username,
 ) ([]screenjournal.EmailSubscriber, error) {
-	rows, err := s.ctx.Query(`
+	rows, err := s.db.Query(`
 	SELECT
 		users.username AS username,
 		users.email AS email
@@ -103,7 +103,7 @@ func (s Store) ReadCommentSubscribers(
 func (s Store) ReadNotificationPreferences(username screenjournal.Username) (screenjournal.NotificationPreferences, error) {
 	var newReviews bool
 	var allNewComments bool
-	err := s.ctx.QueryRow(`
+	err := s.db.QueryRow(`
 	SELECT
 		new_reviews,
 		all_new_comments
@@ -123,7 +123,7 @@ func (s Store) ReadNotificationPreferences(username screenjournal.Username) (scr
 
 func (s Store) UpdateNotificationPreferences(username screenjournal.Username, prefs screenjournal.NotificationPreferences) error {
 	log.Printf("updating notifications preferences for %s: newReviews=%v, allNewComments=%v", username, prefs.NewReviews, prefs.AllNewComments)
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 	UPDATE notification_preferences
 	SET
 		new_reviews = :new_reviews,

--- a/store/sqlite/password_reset.go
+++ b/store/sqlite/password_reset.go
@@ -14,7 +14,7 @@ import (
 func (s Store) InsertPasswordResetEntry(request screenjournal.PasswordResetEntry) error {
 	log.Printf("inserting new password reset token for user %s", request.Username)
 
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 	INSERT OR REPLACE INTO
 		password_reset_tokens
 	(
@@ -38,7 +38,7 @@ func (s Store) InsertPasswordResetEntry(request screenjournal.PasswordResetEntry
 func (s Store) ReadPasswordResetEntry(token screenjournal.PasswordResetToken) (screenjournal.PasswordResetEntry, error) {
 	var username string
 	var expiresAtRaw string
-	if err := s.ctx.QueryRow(`
+	if err := s.db.QueryRow(`
 		SELECT
 			username,
 			expires_at
@@ -64,7 +64,7 @@ func (s Store) ReadPasswordResetEntry(token screenjournal.PasswordResetToken) (s
 func (s Store) ReadLatestPasswordResetEntryForUser(username screenjournal.Username) (screenjournal.PasswordResetEntry, error) {
 	var tokenRaw string
 	var expiresAtRaw string
-	if err := s.ctx.QueryRow(`
+	if err := s.db.QueryRow(`
 		SELECT
 			token,
 			expires_at
@@ -97,7 +97,7 @@ func (s Store) UsePasswordResetEntry(
 	newPasswordHash screenjournal.PasswordHash,
 	now time.Time,
 ) error {
-	tx, err := s.ctx.BeginTx(context.Background(), nil)
+	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}

--- a/store/sqlite/reactions.go
+++ b/store/sqlite/reactions.go
@@ -15,7 +15,7 @@ func (s Store) ReadReactions(rid screenjournal.ReviewID) ([]screenjournal.Review
 		return []screenjournal.ReviewReaction{}, err
 	}
 
-	rows, err := s.ctx.Query(`
+	rows, err := s.db.Query(`
 	SELECT
 		id,
 		review_id,
@@ -57,7 +57,7 @@ func (s Store) ReadReactions(rid screenjournal.ReviewID) ([]screenjournal.Review
 }
 
 func (s Store) ReadReaction(id screenjournal.ReactionID) (screenjournal.ReviewReaction, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		review_id,
@@ -78,7 +78,7 @@ func (s Store) InsertReaction(rr screenjournal.ReviewReaction) (screenjournal.Re
 
 	now := time.Now()
 
-	res, err := s.ctx.Exec(`
+	res, err := s.db.Exec(`
 	INSERT INTO
 		review_reactions
 	(
@@ -109,7 +109,7 @@ func (s Store) InsertReaction(rr screenjournal.ReviewReaction) (screenjournal.Re
 
 func (s Store) DeleteReaction(id screenjournal.ReactionID) error {
 	log.Printf("deleting reaction ID=%v", id)
-	_, err := s.ctx.Exec(`DELETE FROM review_reactions WHERE id = :id`, sql.Named("id", id.String()))
+	_, err := s.db.Exec(`DELETE FROM review_reactions WHERE id = :id`, sql.Named("id", id.String()))
 	if err != nil {
 		return err
 	}

--- a/store/sqlite/reviews.go
+++ b/store/sqlite/reviews.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s Store) ReadReview(id screenjournal.ReviewID) (screenjournal.Review, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		review_owner,
@@ -101,7 +101,7 @@ func (s Store) ReadReviews(opts ...store.ReadReviewsOption) ([]screenjournal.Rev
 	}
 	query += "		created_time DESC\n"
 
-	rows, err := s.ctx.Query(query, queryArgs...)
+	rows, err := s.db.Query(query, queryArgs...)
 	if err != nil {
 		return []screenjournal.Review{}, err
 	}
@@ -164,7 +164,7 @@ func (s Store) InsertReview(r screenjournal.Review) (screenjournal.ReviewID, err
 		tvShowSeason = &r.TvShowSeason
 	}
 
-	res, err := s.ctx.Exec(`
+	res, err := s.db.Exec(`
 	INSERT INTO
 		reviews
 	(
@@ -216,7 +216,7 @@ func (s Store) UpdateReview(r screenjournal.Review) error {
 
 	now := time.Now()
 
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 	UPDATE reviews
 	SET
 		rating = :rating,
@@ -239,7 +239,7 @@ func (s Store) UpdateReview(r screenjournal.Review) error {
 func (s Store) DeleteReview(id screenjournal.ReviewID) error {
 	log.Printf("deleting review and commments for review ID %v", id)
 
-	tx, err := s.ctx.BeginTx(context.Background(), nil)
+	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -17,7 +17,7 @@ const (
 
 type (
 	Store struct {
-		ctx *sql.DB
+		db *sql.DB
 	}
 
 	rowScanner interface {
@@ -34,15 +34,15 @@ func MustOpen(path string) *sql.DB {
 	return ctx
 }
 
-func New(ctx *sql.DB, optimizeForLitestream bool) Store {
-	if _, err := ctx.Exec(`
+func New(db *sql.DB, optimizeForLitestream bool) Store {
+	if _, err := db.Exec(`
 		PRAGMA temp_store = FILE;
 		PRAGMA journal_mode = WAL;
 		`); err != nil {
 		log.Fatalf("failed to set pragmas: %v", err)
 	}
 
-	store := Store{ctx: ctx}
+	store := Store{db: db}
 	if optimizeForLitestream {
 		store.optimizeForLitestream()
 	}

--- a/store/sqlite/tv_shows.go
+++ b/store/sqlite/tv_shows.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s Store) ReadTvShow(id screenjournal.TvShowID) (screenjournal.TvShow, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		tmdb_id,
@@ -27,7 +27,7 @@ func (s Store) ReadTvShow(id screenjournal.TvShowID) (screenjournal.TvShow, erro
 }
 
 func (s Store) ReadTvShowByTmdbID(tmdbID screenjournal.TmdbID) (screenjournal.TvShow, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		id,
 		tmdb_id,
@@ -46,7 +46,7 @@ func (s Store) ReadTvShowByTmdbID(tmdbID screenjournal.TmdbID) (screenjournal.Tv
 func (s Store) InsertTvShow(t screenjournal.TvShow) (screenjournal.TvShowID, error) {
 	log.Printf("inserting new TV show %s", t.Title)
 
-	res, err := s.ctx.Exec(`
+	res, err := s.db.Exec(`
 	INSERT INTO
 		tv_shows
 	(
@@ -80,7 +80,7 @@ func (s Store) InsertTvShow(t screenjournal.TvShow) (screenjournal.TvShowID, err
 func (s Store) UpdateTvShow(t screenjournal.TvShow) error {
 	log.Printf("updating TV show %s", t.Title)
 
-	_, err := s.ctx.Exec(`
+	_, err := s.db.Exec(`
 	UPDATE
 		tv_shows
 	SET

--- a/store/sqlite/users.go
+++ b/store/sqlite/users.go
@@ -16,14 +16,14 @@ import (
 
 func (s Store) CountUsers() (uint, error) {
 	var c uint
-	if err := s.ctx.QueryRow(`SELECT COUNT(*)	AS user_count FROM users`).Scan(&c); err != nil {
+	if err := s.db.QueryRow(`SELECT COUNT(*)	AS user_count FROM users`).Scan(&c); err != nil {
 		return 0, err
 	}
 	return c, nil
 }
 
 func (s Store) ReadUsersPublicMeta() ([]screenjournal.UserPublicMeta, error) {
-	rows, err := s.ctx.Query(`
+	rows, err := s.db.Query(`
 	SELECT
     u.username,
     u.created_time,
@@ -75,7 +75,7 @@ func (s Store) ReadUsersPublicMeta() ([]screenjournal.UserPublicMeta, error) {
 }
 
 func (s Store) ReadUser(username screenjournal.Username) (screenjournal.User, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		username,
 		is_admin,
@@ -97,7 +97,7 @@ func (s Store) ReadUser(username screenjournal.Username) (screenjournal.User, er
 }
 
 func (s Store) ReadUserByEmail(email screenjournal.Email) (screenjournal.User, error) {
-	row := s.ctx.QueryRow(`
+	row := s.db.QueryRow(`
 	SELECT
 		username,
 		is_admin,
@@ -139,7 +139,7 @@ func (s Store) InsertUser(user screenjournal.User) error {
 
 	now := time.Now()
 
-	tx, err := s.ctx.BeginTx(context.Background(), nil)
+	tx, err := s.db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (s Store) InsertUser(user screenjournal.User) error {
 func (s Store) UpdateUserPassword(username screenjournal.Username, newPasswordHash screenjournal.PasswordHash) error {
 	log.Printf("updating password user %s", username.String())
 
-	if _, err := s.ctx.Exec(`
+	if _, err := s.db.Exec(`
 	UPDATE users
 	SET
 		password_hash = :password_hash

--- a/store/sqlite/wipe_dev.go
+++ b/store/sqlite/wipe_dev.go
@@ -6,19 +6,19 @@ import "log"
 
 func (s Store) Clear() {
 	log.Printf("clearing all SQLite tables")
-	if _, err := s.ctx.Exec(`DELETE FROM movies`); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM movies`); err != nil {
 		log.Fatalf("failed to delete movies: %v", err)
 	}
-	if _, err := s.ctx.Exec(`DELETE FROM reviews`); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM reviews`); err != nil {
 		log.Fatalf("failed to delete reviews: %v", err)
 	}
-	if _, err := s.ctx.Exec(`DELETE FROM users`); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM users`); err != nil {
 		log.Fatalf("failed to delete users: %v", err)
 	}
-	if _, err := s.ctx.Exec(`DELETE FROM invites`); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM invites`); err != nil {
 		log.Fatalf("failed to delete invites: %v", err)
 	}
-	if _, err := s.ctx.Exec(`DELETE FROM notification_preferences`); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM notification_preferences`); err != nil {
 		log.Fatalf("failed to delete notification_preferences: %v", err)
 	}
 }


### PR DESCRIPTION
Rename the sqlite.Store field from ctx to db and update all internal call sites accordingly.

Using ctx for a *sql.DB is confusing because ctx is the conventional identifier for context.Context throughout Go code. Naming the database handle db makes the type and purpose obvious at the call site and avoids suggesting that Store carries a request-scoped context value.