### PR TITLE
Add ETag caching for static assets

### DIFF
--- a/handlers/static.go
+++ b/handlers/static.go
@@ -1,13 +1,21 @@
 package handlers
 
 import (
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
+	"fmt"
 	"io/fs"
 	"net/http"
+	"strings"
+	"time"
 )
 
 //go:embed static/*
 var staticFiles embed.FS
+
+// Changing this token on process start invalidates every static asset ETag.
+var staticETagVersion = fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 
 // noDirFS wraps an fs.FS to disable directory listing.
 type noDirFS struct {
@@ -37,13 +45,34 @@ func (n noDirFS) Open(name string) (fs.File, error) {
 // cachingFileServer wraps an http.Handler to add caching headers.
 func cachingFileServer(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Add cache control headers.
-		w.Header().Set("Cache-Control", "public, max-age=604800") // 1 week.
+		etag := staticAssetETag(r.URL.Path)
+		w.Header().Set("Cache-Control", "public, max-age=1800")
+		w.Header().Set("ETag", etag)
+		if requestHasMatchingETag(r, etag) {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
 
 		// Let the original handler serve the file. The FileServer will handle
 		// Last-Modified and If-Modified-Since automatically.
 		h.ServeHTTP(w, r)
 	})
+}
+
+// staticAssetETag returns a stable ETag for one asset during a server run.
+func staticAssetETag(path string) string {
+	hash := sha256.Sum256([]byte(staticETagVersion + "\n" + path))
+	return fmt.Sprintf(`"%s"`, hex.EncodeToString(hash[:]))
+}
+
+// requestHasMatchingETag reports whether the client already has this asset.
+func requestHasMatchingETag(r *http.Request, etag string) bool {
+	for _, rawValue := range strings.Split(r.Header.Get("If-None-Match"), ",") {
+		if strings.TrimSpace(rawValue) == etag {
+			return true
+		}
+	}
+	return false
 }
 
 // getStaticFilesHandler returns an http.Handler that serves static files from

--- a/handlers/static_cache_test.go
+++ b/handlers/static_cache_test.go
@@ -1,0 +1,109 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mtlynch/screenjournal/v2/handlers"
+	"github.com/mtlynch/screenjournal/v2/store/test_sqlite"
+)
+
+func TestStaticFilesUseCacheControlAndETag(t *testing.T) {
+	server := newStaticFileTestServer()
+	responseRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/css/screenjournal.css",
+		nil,
+	)
+
+	server.Router().ServeHTTP(responseRecorder, request)
+
+	if got, want := responseRecorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status=%d, want=%d", got, want)
+	}
+	if got, want := responseRecorder.Header().Get("Cache-Control"), "public, max-age=1800"; got != want {
+		t.Errorf("Cache-Control=%q, want=%q", got, want)
+	}
+	if got := responseRecorder.Header().Get("ETag"); got == "" {
+		t.Errorf("ETag header is empty")
+	}
+}
+
+func TestStaticFilesReturnNotModifiedForMatchingETag(t *testing.T) {
+	server := newStaticFileTestServer()
+
+	firstResponseRecorder := httptest.NewRecorder()
+	firstRequest := httptest.NewRequest(
+		http.MethodGet,
+		"/css/screenjournal.css",
+		nil,
+	)
+	server.Router().ServeHTTP(firstResponseRecorder, firstRequest)
+
+	if got, want := firstResponseRecorder.Code, http.StatusOK; got != want {
+		t.Fatalf("initial status=%d, want=%d", got, want)
+	}
+
+	cachedETag := firstResponseRecorder.Header().Get("ETag")
+	if cachedETag == "" {
+		t.Fatalf("initial ETag header is empty")
+	}
+
+	secondResponseRecorder := httptest.NewRecorder()
+	secondRequest := httptest.NewRequest(
+		http.MethodGet,
+		"/css/screenjournal.css",
+		nil,
+	)
+	secondRequest.Header.Set("If-None-Match", cachedETag)
+
+	server.Router().ServeHTTP(secondResponseRecorder, secondRequest)
+
+	if got, want := secondResponseRecorder.Code, http.StatusNotModified; got != want {
+		t.Fatalf("status=%d, want=%d", got, want)
+	}
+	if got, want := secondResponseRecorder.Header().Get("Cache-Control"), "public, max-age=1800"; got != want {
+		t.Errorf("Cache-Control=%q, want=%q", got, want)
+	}
+	if got, want := secondResponseRecorder.Header().Get("ETag"), cachedETag; got != want {
+		t.Errorf("ETag=%q, want=%q", got, want)
+	}
+	if got, want := secondResponseRecorder.Body.Len(), 0; got != want {
+		t.Errorf("body length=%d, want=%d", got, want)
+	}
+}
+
+func TestStaticFilesServeFontawesomeWebfontRanges(t *testing.T) {
+	server := newStaticFileTestServer()
+	responseRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/third-party/fontawesome@6.2.0/webfonts/fa-solid-900.ttf",
+		nil,
+	)
+	request.Header.Set("Range", "bytes=0-1")
+
+	server.Router().ServeHTTP(responseRecorder, request)
+
+	if got, want := responseRecorder.Code, http.StatusPartialContent; got != want {
+		t.Fatalf(
+			"status=%d, want=%d, body=%q",
+			got,
+			want,
+			responseRecorder.Body.String(),
+		)
+	}
+	if got, want := responseRecorder.Body.Len(), 2; got != want {
+		t.Errorf("body length=%d, want=%d", got, want)
+	}
+}
+
+func newStaticFileTestServer() handlers.Server {
+	sessionManager := newMockSessionManager(nil)
+	return handlers.New(handlers.ServerParams{
+		SessionManager: &sessionManager,
+		Store:          test_sqlite.New(),
+	})
+}


### PR DESCRIPTION
Set short-lived Cache-Control and process-stable ETags for embedded static files, and cover cache validation plus font range requests.