### PR TITLE
Render templates through a buffer

### DIFF
--- a/handlers/activity.go
+++ b/handlers/activity.go
@@ -63,16 +63,13 @@ func (s Server) activityGet() http.HandlerFunc {
 			reviews[i].Reactions = rr
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Groups []activityGroup
 		}{
 			commonProps: makeCommonProps(r.Context()),
 			Groups:      buildActivityGroups(reviews),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 

--- a/handlers/comments.go
+++ b/handlers/comments.go
@@ -34,15 +34,11 @@ func (s Server) commentsAddGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.ExecuteTemplate(w, "add-comment-button", struct {
+		renderTemplate(w, t, "add-comment-button", struct {
 			ID screenjournal.ReviewID
 		}{
 			ID: reviewID,
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render add comment button: %v", err)
-			return
-		}
+		})
 	}
 }
 
@@ -81,7 +77,7 @@ func (s Server) commentsEditGet() http.HandlerFunc {
 			commentText = *pCommentText
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "comments-edit.html", struct {
 			ReviewID    screenjournal.ReviewID
 			CommentID   screenjournal.CommentID
 			CommentText screenjournal.CommentText
@@ -89,11 +85,7 @@ func (s Server) commentsEditGet() http.HandlerFunc {
 			ReviewID:    reviewID,
 			CommentID:   commentID,
 			CommentText: commentText,
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render edit comment template: %v", err)
-			return
-		}
+		})
 	}
 }
 
@@ -118,17 +110,13 @@ func (s Server) commentsGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.ExecuteTemplate(w, "comment", struct {
+		renderTemplate(w, t, "comment", struct {
 			Comment          screenjournal.ReviewComment
 			LoggedInUsername screenjournal.Username
 		}{
 			Comment:          rc,
 			LoggedInUsername: mustGetUsernameFromContext(r.Context()),
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render comment: %v", err)
-			return
-		}
+		})
 	}
 }
 
@@ -169,15 +157,13 @@ func (s Server) commentsPost() http.HandlerFunc {
 		// the correct creation time.
 		rc.Created = time.Now()
 
-		if err := t.ExecuteTemplate(w, "comment", struct {
+		if !renderTemplate(w, t, "comment", struct {
 			Comment          screenjournal.ReviewComment
 			LoggedInUsername screenjournal.Username
 		}{
 			Comment:          rc,
 			LoggedInUsername: mustGetUsernameFromContext(r.Context()),
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render comment: %v", err)
+		}) {
 			return
 		}
 
@@ -219,17 +205,13 @@ func (s Server) commentsPut() http.HandlerFunc {
 			return
 		}
 
-		if err := t.ExecuteTemplate(w, "comment", struct {
+		renderTemplate(w, t, "comment", struct {
 			Comment          screenjournal.ReviewComment
 			LoggedInUsername screenjournal.Username
 		}{
 			Comment:          rc,
 			LoggedInUsername: mustGetUsernameFromContext(r.Context()),
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render comment: %v", err)
-			return
-		}
+		})
 	}
 }
 

--- a/handlers/invites.go
+++ b/handlers/invites.go
@@ -33,17 +33,13 @@ func (s Server) invitesPost() http.HandlerFunc {
 			return
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "invite-row.html", struct {
 			Invitee    screenjournal.Invitee
 			InviteCode screenjournal.InviteCode
 		}{
 			Invitee:    invitation.Invitee,
 			InviteCode: invitation.InviteCode,
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render invite row template: %v", err)
-			return
-		}
+		})
 	}
 
 }

--- a/handlers/password_reset.go
+++ b/handlers/password_reset.go
@@ -89,17 +89,14 @@ func (s Server) resetPasswordGet() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		serverSupportsPasswordResets := s.passwordResetterForRequest() != nil
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Submitted                    bool
 			ServerSupportsPasswordResets bool
 		}{
 			commonProps:                  makeCommonProps(r.Context()),
 			ServerSupportsPasswordResets: serverSupportsPasswordResets,
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -120,7 +117,7 @@ func (s Server) resetPasswordPost() http.HandlerFunc {
 		// Always render the same success page regardless of account lookup
 		// outcome.
 		renderSuccess := func() {
-			if err := pageTemplate.Execute(w, struct {
+			renderTemplate(w, pageTemplate, "base.html", struct {
 				commonProps
 				Submitted                    bool
 				ServerSupportsPasswordResets bool
@@ -128,9 +125,7 @@ func (s Server) resetPasswordPost() http.HandlerFunc {
 				commonProps:                  makeCommonProps(r.Context()),
 				Submitted:                    true,
 				ServerSupportsPasswordResets: true,
-			}); err != nil {
-				log.Printf("failed to render reset password success page: %v", err)
-			}
+			})
 		}
 
 		emailAddr, err := parse.Email(r.FormValue("email"))

--- a/handlers/reactions.go
+++ b/handlers/reactions.go
@@ -91,7 +91,7 @@ func (s Server) reactionsPost() http.HandlerFunc {
 		// Convert reactions to template format.
 		reactionsForTemplate := convertReactionsForTemplate(reactions, loggedInUsername, isAdminUser)
 
-		if err := t.ExecuteTemplate(w, "reactions-section", struct {
+		renderTemplate(w, t, "reactions-section", struct {
 			ReviewID         screenjournal.ReviewID
 			Reactions        []reactionForTemplate
 			UserHasReacted   bool
@@ -103,11 +103,7 @@ func (s Server) reactionsPost() http.HandlerFunc {
 			UserHasReacted:   true,
 			AvailableEmojis:  screenjournal.AllowedReactionEmojis(),
 			LoggedInUsername: loggedInUsername,
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render reactions section: %v", err)
-			return
-		}
+		})
 	}
 }
 

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -65,15 +65,11 @@ func (s Server) searchGet() http.HandlerFunc {
 			})
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "search-results.html", struct {
 			Results []searchMatch
 		}{
 			Results: matches,
-		}); err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-			log.Printf("failed to render search results template: %v", err)
-			return
-		}
+		})
 	}
 }
 

--- a/handlers/templates.go
+++ b/handlers/templates.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"bytes"
+	"html/template"
+	"log"
+	"net/http"
+)
+
+// renderTemplate executes the named template with data and writes the result to
+// w. It renders into a buffer first so a mid-render failure becomes a clean 500
+// instead of a partially written response.
+func renderTemplate(w http.ResponseWriter, t *template.Template, name string, data any) bool {
+	var body bytes.Buffer
+	if err := t.ExecuteTemplate(&body, name, data); err != nil {
+		log.Printf("failed to render %q template: %v", name, err)
+		http.Error(w, "Failed to render HTML template", http.StatusInternalServerError)
+		return false
+	}
+
+	_, _ = body.WriteTo(w)
+	return true
+}

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -181,14 +181,11 @@ func (s Server) indexGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 		}{
 			commonProps: makeCommonProps(r.Context()),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -199,14 +196,11 @@ func (s Server) aboutGet() http.HandlerFunc {
 				templatesFS,
 				append(baseTemplates, "templates/pages/about.html")...))
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 		}{
 			commonProps: makeCommonProps(r.Context()),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -217,14 +211,11 @@ func (s Server) logInGet() http.HandlerFunc {
 				templatesFS,
 				append(baseTemplates, "templates/pages/login.html")...))
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 		}{
 			commonProps: makeCommonProps(r.Context()),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -279,7 +270,7 @@ func (s Server) signUpGet() http.HandlerFunc {
 			suggestedUsername = nonSuggestedCharsPattern.ReplaceAllString(strings.ToLower(firstPart), "")
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Invitee           screenjournal.Invitee
 			SuggestedUsername string
@@ -287,10 +278,7 @@ func (s Server) signUpGet() http.HandlerFunc {
 			commonProps:       makeCommonProps(r.Context()),
 			Invitee:           invite.Invitee,
 			SuggestedUsername: suggestedUsername,
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -357,7 +345,7 @@ func (s Server) reviewsGet() http.HandlerFunc {
 			title = fmt.Sprintf("%s's %s", collectionOwner, title)
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Title            string
 			Reviews          []screenjournal.Review
@@ -371,10 +359,7 @@ func (s Server) reviewsGet() http.HandlerFunc {
 			SortOrder:        sortOrder,
 			CollectionOwner:  collectionOwner,
 			UserCanAddReview: collectionOwner == nil || collectionOwner.Equal(mustGetUsernameFromContext(r.Context())),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -444,7 +429,7 @@ func (s Server) moviesReadGet() http.HandlerFunc {
 			TmdbID       screenjournal.TmdbID
 			ReleaseDate  screenjournal.ReleaseDate
 		}
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Media           mediaStub
 			Reviews         []reviewViewModel
@@ -463,10 +448,7 @@ func (s Server) moviesReadGet() http.HandlerFunc {
 			},
 			Reviews:         reviewsForTemplate,
 			AvailableEmojis: screenjournal.AllowedReactionEmojis(),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -544,7 +526,7 @@ func (s Server) tvShowsReadGet() http.HandlerFunc {
 			ReleaseDate  screenjournal.ReleaseDate
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Media           mediaStub
 			Reviews         []reviewViewModel
@@ -564,11 +546,7 @@ func (s Server) tvShowsReadGet() http.HandlerFunc {
 			},
 			Reviews:         reviewsForTemplate,
 			AvailableEmojis: screenjournal.AllowedReactionEmojis(),
-		}); err != nil {
-			log.Printf("failed to render template: %v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -610,7 +588,7 @@ func (s Server) reviewsEditGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			RatingOptions []ratingOption
 			Review        screenjournal.Review
@@ -622,11 +600,7 @@ func (s Server) reviewsEditGet() http.HandlerFunc {
 			Review:        review,
 			MediaType:     mediaType,
 			Today:         time.Now(),
-		}); err != nil {
-			log.Printf("failed to execute template: %v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -641,14 +615,11 @@ func (s Server) reviewsNewTitleSearchGet() http.HandlerFunc {
 					"templates/pages/reviews-new.html")...))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 		}{
 			commonProps: makeCommonProps(r.Context()),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -691,7 +662,7 @@ func (s Server) reviewsNewPickSeasonGet() http.HandlerFunc {
 			seasonOptions[i] = i + 1
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			TmdbID        screenjournal.TmdbID
 			TvShowTitle   screenjournal.MediaTitle
@@ -703,10 +674,7 @@ func (s Server) reviewsNewPickSeasonGet() http.HandlerFunc {
 			TvShowTitle:   tvShow.Title,
 			ReleaseYear:   tvShow.AirDate.Year(),
 			SeasonOptions: seasonOptions,
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -804,7 +772,7 @@ func (s Server) reviewsNewWriteReviewGet() http.HandlerFunc {
 			tvShowSeason = season
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			RatingOptions []ratingOption
 			Review        screenjournal.Review
@@ -821,11 +789,7 @@ func (s Server) reviewsNewWriteReviewGet() http.HandlerFunc {
 			},
 			MediaType: mediaType,
 			Today:     time.Now(),
-		}); err != nil {
-			log.Printf("failed to execute template: %v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -881,16 +845,13 @@ func (s Server) invitesGet() http.HandlerFunc {
 			http.Error(w, "Failed to read signup invitations", http.StatusInternalServerError)
 			return
 		}
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Invites []screenjournal.SignupInvitation
 		}{
 			commonProps: makeCommonProps(r.Context()),
 			Invites:     invites,
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -931,7 +892,7 @@ func (s Server) accountPasswordResetGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Token         string
 			FormTargetURL string
@@ -941,10 +902,7 @@ func (s Server) accountPasswordResetGet() http.HandlerFunc {
 			Token:         token.String(),
 			FormTargetURL: fmt.Sprintf("/account/password-reset?username=%s&token=%s", username, token),
 			CancelURL:     "/login",
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -955,7 +913,7 @@ func (s Server) accountChangePasswordGet() http.HandlerFunc {
 			append(baseTemplates, "templates/pages/account-change-password.html")...))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Token         string
 			FormTargetURL string
@@ -965,10 +923,7 @@ func (s Server) accountChangePasswordGet() http.HandlerFunc {
 			Token:         "",
 			FormTargetURL: "/account/password",
 			CancelURL:     "/account/security",
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -986,7 +941,7 @@ func (s Server) accountNotificationsGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			ReceivesReviewNotices     bool
 			ReceivesAllCommentNotices bool
@@ -994,10 +949,7 @@ func (s Server) accountNotificationsGet() http.HandlerFunc {
 			commonProps:               makeCommonProps(r.Context()),
 			ReceivesReviewNotices:     prefs.NewReviews,
 			ReceivesAllCommentNotices: prefs.AllNewComments,
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -1008,14 +960,11 @@ func (s Server) accountSecurityGet() http.HandlerFunc {
 			append(baseTemplates, "templates/pages/account-security.html")...))
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 		}{
 			commonProps: makeCommonProps(r.Context()),
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 
@@ -1034,16 +983,13 @@ func (s Server) usersGet() http.HandlerFunc {
 			return
 		}
 
-		if err := t.Execute(w, struct {
+		renderTemplate(w, t, "base.html", struct {
 			commonProps
 			Users []screenjournal.UserPublicMeta
 		}{
 			commonProps: makeCommonProps(r.Context()),
 			Users:       users,
-		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
Use a shared buffered renderer so template execution failures return a clean 500 instead of a partially-written successful response.