### PR TITLE
Downgrade pnpm to 10.25.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Download pnpm packages
           command: |
-            sudo npm install --global pnpm@11.5.3
+            sudo npm install --global pnpm@10.25.0
             pnpm install --frozen-lockfile
       - run:
           name: Run frontend checks
@@ -108,7 +108,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            npm install --global pnpm@11.5.3
+            npm install --global pnpm@10.25.0
             pnpm install --frozen-lockfile
       - run:
           name: Run e2e tests

--- a/flake.lock
+++ b/flake.lock
@@ -100,17 +100,17 @@
     },
     "pnpm-nixpkgs": {
       "locked": {
-        "lastModified": 1781454065,
-        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
+        "lastModified": 1765934234,
+        "narHash": "sha256-pJjWUzNnjbIAMIc5gRFUuKCDQ9S1cuh3b2hKgA7Mc4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "rev": "af84f9d270d404c17699522fab95bbf928a2d92f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "rev": "af84f9d270d404c17699522fab95bbf928a2d92f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
     # 24.15.0 release
     nodejs-nixpkgs.url = "github:NixOS/nixpkgs/9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc";
 
-    # 11.5.3 release
-    pnpm-nixpkgs.url = "github:NixOS/nixpkgs/9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc";
+    # 10.25.0 release
+    pnpm-nixpkgs.url = "github:NixOS/nixpkgs/af84f9d270d404c17699522fab95bbf928a2d92f";
 
     # 0.10.0 release
     shellcheck-nixpkgs.url = "github:NixOS/nixpkgs/4ae2e647537bcdbb82265469442713d066675275";
@@ -53,7 +53,7 @@
       go = gopkg.go_1_26;
       sqlite = sqlite-nixpkgs.legacyPackages.${system}.sqlite;
       nodejs = nodejs-nixpkgs.legacyPackages.${system}.nodejs_24;
-      pnpm = pnpm-nixpkgs.legacyPackages.${system}.pnpm;
+      pnpm = pnpm-nixpkgs.legacyPackages.${system}.pnpm_10.override {inherit nodejs;};
       shellcheck = shellcheck-nixpkgs.legacyPackages.${system}.shellcheck;
       sqlfluff = sqlfluff-nixpkgs.legacyPackages.${system}.sqlfluff;
       playwright = playwright-nixpkgs.legacyPackages.${system}.playwright-driver.browsers;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "screenjournal-dev",
   "version": "1.0.0",
-  "packageManager": "pnpm@11.5.3",
+  "packageManager": "pnpm@10.25.0",
   "description": "ScreenJournal dev tools",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The upcoming refactoring for e2e tests (#507) is harder with pnpm 11, and there's no special need for v11, so downgrade for now.